### PR TITLE
[chore #165412906] integrate coveralls code caverage service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+env:
+global:
+- CC_TEST_REPORTER_ID=d570e2625aaffa20e7828eaddfbec748c525e866b6d413472bc26e188cb2bc6a
+language: node_js
+node_js:
+- "stable"
+cache:
+directories:
+- "node_modules"
+before_script:
+- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+- chmod +x ./cc-test-reporter
+- ./cc-test-reporter before-build
+after_script:
+- ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+after_success:
+- npm run coverage

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/andela/ninjas-ah-backend.svg?branch=develop)](https://travis-ci.org/andela/ninjas-ah-backend)
+[![Coverage Status](https://coveralls.io/repos/github/andela/ninjas-ah-backend/badge.svg?branch=develop)](https://coveralls.io/github/andela/ninjas-ah-backend?branch=develop) [![Build Status](https://travis-ci.org/andela/ninjas-ah-backend.svg?branch=develop)](https://travis-ci.org/andela/ninjas-ah-backend) [![Test Coverage](https://api.codeclimate.com/v1/badges/4635ecd43e1b06546534/test_coverage)](https://codeclimate.com/github/andela/ninjas-ah-backend/test_coverage) 
 
 Authors Haven - A Social platform for the creative at heart.
 =======

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "babel-node src/index.js",
-    "dev": "nodemon src/index.js --exec babel-node --presets @babel/preset-env"
+    "dev": "nodemon src/index.js --exec babel-node --presets @babel/preset-env",
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "show-coverage": "xdg-open coverage/index.html"
   },
   "author": "Andela Simulations Programme",
   "license": "MIT",


### PR DESCRIPTION
### What does this PR do?
 This PR integrates coveralls code coverage service
#### Description of Task to be completed?
Configure code coverage script in package.json and .travis.yml for coveralls
#### How should this be manually tested?
You can test this by visiting andela/ninjas-ah-backend and scroll down to see coveralls budge in README
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
 - #165412906
#### Screenshots (if appropriate)
- N/A
#### Questions:
- N/A